### PR TITLE
Evaluate the command `CLIPBOARD[get]`.

### DIFF
--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -67,7 +67,7 @@ function _zsh_system_clipboard_api() {
 	}
 
 	function sub_get() {
-		echo -E $(${CLIPBOARD[get]})
+		echo -E $(eval ${CLIPBOARD[get]})
 	}
 
 	local subcommand=${1:-''}


### PR DESCRIPTION
On Linux, the command stored in this variable contains spaces so it
needs to be evaluated.