### PR TITLE
Automatically rebind keys after current settings

### DIFF
--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -8,141 +8,189 @@
 # @version v0.6.0
 ##
 
-# Enable vi emulation mode explicitly.
-setopt VI
+function _zsh_system_clipboard() {
+	function error() {
+		echo -e "\n\n  \033[41;37m ERROR \033[0m \033[01mzsh-system-clipboard:\033[0m $@\n" >&2
+	}
 
-function error() {
-	echo -e "\n\n  \033[41;37m ERROR \033[0m \033[01mzsh-system-clipboard:\033[0m $@\n" >&2
-}
+	function suggest_to_install() {
+		error "Could not find any available clipboard manager. Make sure you have \033[01m${@}\033[0m installed."
+	}
 
-function suggest_to_install() {
-	error "Could not find any available clipboard manager. Make sure you have \033[01m${@}\033[0m installed."
-}
+	local -A CLIPBOARD
 
-declare -A ZSH_SYSTEM_CLIPBOARD
-case "$OSTYPE" {
-	darwin*)
-		if ((hash pbcopy && hash pbpaste) 2>/dev/null) {
-			typeset -g ZSH_SYSTEM_CLIPBOARD[set]='pbcopy'
-			typeset -g ZSH_SYSTEM_CLIPBOARD[get]='pbpaste'
-		} else {
-			suggest_to_install 'pbcopy, pbpaste'
-		}
-		;;
-	linux-android*)
-		if ((hash termux-clipboard-set && hash termux-clipboard-get) 2>/dev/null) {
-			typeset -g ZSH_SYSTEM_CLIPBOARD[set]='termux-clipboard-set'
-			typeset -g ZSH_SYSTEM_CLIPBOARD[get]='termux-clipboard-get'
-		} else {
-			suggest_to_install 'Termux:API (from Play Store), termux-api (from apt package)'
-		}
-		;;
-	linux*|freebsd*)
-		if (hash xclip 2>/dev/null) {
-			local clipboard_selection
-			case $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION {
-				PRIMARY)
-					clipboard_selection='PRIMARY'
-					;;
-				CLIPBOARD)
-					clipboard_selection='CLIPBOARD'
-					;;
-				*)
-					if [[ $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION != '' ]] {
-						error "\033[01m$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION\033[0m is not a valid value for \$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION. Please assign either 'PRIMARY' or 'CLIPBOARD'."
-					} else {
-						clipboard_selection='CLIPBOARD'
+	function () {
+		case "$OSTYPE" {
+			darwin*)
+				if ((hash pbcopy && hash pbpaste) 2>/dev/null) {
+					typeset -g CLIPBOARD[set]='pbcopy'
+					typeset -g CLIPBOARD[get]='pbpaste'
+				} else {
+					suggest_to_install 'pbcopy, pbpaste'
+				}
+				;;
+
+			linux-android*)
+				if ((hash termux-clipboard-set && hash termux-clipboard-get) 2>/dev/null) {
+					typeset -g CLIPBOARD[set]='termux-clipboard-set'
+					typeset -g CLIPBOARD[get]='termux-clipboard-get'
+				} else {
+					suggest_to_install 'Termux:API (from Play Store), termux-api (from apt package)'
+				}
+				;;
+
+			linux*|freebsd*)
+				if (hash xclip 2>/dev/null) {
+					local clipboard_selection
+
+					case $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION {
+						PRIMARY)
+							clipboard_selection='PRIMARY'
+							;;
+
+						CLIPBOARD)
+							clipboard_selection='CLIPBOARD'
+							;;
+
+						*)
+							if [[ $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION != '' ]] {
+								error "\033[01m$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION\033[0m is not a valid value for \$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION. Please assign either 'PRIMARY' or 'CLIPBOARD'."
+
+							} else {
+								clipboard_selection='CLIPBOARD'
+							}
+							;;
 					}
-					;;
-			}
-			typeset -g ZSH_SYSTEM_CLIPBOARD[set]="xclip -sel $clipboard_selection -in"
-			typeset -g ZSH_SYSTEM_CLIPBOARD[get]="xclip -sel $clipboard_selection -out"
-		} else {
-			suggest_to_install 'xclip'
-		}
-		;;
-	*)
-		error 'Unsupported system.'
-		;;
-}
-unfunction error
-unfunction suggest_to_install
 
-function _zsh_system_clipboard_set() {
-	if [[ "$ZSH_SYSTEM_CLIPBOARD_TMUX_SUPPORT" != '' ]] {
-		# Set also tmux clipboard buffer if tmux available.
-		if (hash tmux &>/dev/null && [[ "$TMUX" != '' ]]) {
-			tmux set-buffer -- "$*"
+					typeset -g CLIPBOARD[set]="xclip -sel $clipboard_selection -in"
+					typeset -g CLIPBOARD[get]="xclip -sel $clipboard_selection -out"
+				} else {
+					suggest_to_install 'xclip'
+				}
+				;;
+
+			*)
+				error 'Unsupported system.'
+				;;
 		}
 	}
-	echo -E "$*" | eval "${ZSH_SYSTEM_CLIPBOARD[set]}"
-	return true
-}
-function _zsh_system_clipboard_get() {
-	eval "${ZSH_SYSTEM_CLIPBOARD[get]}"
-	return true
+
+	function sub_set() {
+		if [[ "$ZSH_SYSTEM_CLIPBOARD_TMUX_SUPPORT" != '' ]] {
+			# Set also tmux clipboard buffer if tmux available.
+			if (hash tmux &>/dev/null && [[ "$TMUX" != '' ]]) {
+				tmux set-buffer -- "$@"
+			}
+		}
+
+		echo -E "$@" | eval "${CLIPBOARD[set]}"
+	}
+
+	function sub_get() {
+		echo -E $(eval ${CLIPBOARD[get]})
+	}
+
+	local subcommand=${1:-''}
+
+	case "$subcommand" {
+		set)
+			shift
+			sub_${subcommand} "$*"
+
+			return true
+			;;
+
+		get)
+			shift
+			sub_${subcommand}
+
+			return true
+			;;
+
+		*)
+			return false
+	}
 }
 
 # Copy selection.
-function zsh-system-clipboard-key-y() {
+function zsh-system-clipboard-yank() {
 	zle vi-yank
-	_zsh_system_clipboard_set "$CUTBUFFER"
+	_zsh_system_clipboard set "$CUTBUFFER"
 }
+zle -N zsh-system-clipboard-yank
 
 # Copy whole line.
-function zsh-system-clipboard-key-Y() {
+function zsh-system-clipboard-yank-whole-line() {
 	zle vi-yank-whole-line
-	_zsh_system_clipboard_set "$CUTBUFFER"
+	_zsh_system_clipboard set "$CUTBUFFER"
 }
+zle -N zsh-system-clipboard-yank-whole-line
 
-# Copy whole line.
-function zsh-system-clipboard-key-yy() {
-	zsh-system-clipboard-key-Y
-}
-
-# Paster after cursor.
-function zsh-system-clipboard-key-p() {
-	local CLIPBOARD=$(_zsh_system_clipboard_get)
+# Paste after cursor.
+function zsh-system-clipboard-put-after() {
+	local CLIPBOARD=$(_zsh_system_clipboard get)
 
 	BUFFER="${BUFFER:0:$(( ${CURSOR} + 1 ))}${CLIPBOARD}${BUFFER:$(( ${CURSOR} + 1 ))}"
 	CURSOR=$(( $#LBUFFER + $#CLIPBOARD ))
 }
+zle -N zsh-system-clipboard-put-after
 
 # Paste before cursor.
-function zsh-system-clipboard-key-P() {
-	local CLIPBOARD=$(_zsh_system_clipboard_get)
+function zsh-system-clipboard-put-before() {
+	local CLIPBOARD=$(_zsh_system_clipboard get)
 
 	BUFFER="${BUFFER:0:$(( ${CURSOR} ))}${CLIPBOARD}${BUFFER:$(( ${CURSOR} ))}"
 	CURSOR=$(( $#LBUFFER + $#CLIPBOARD - 1 ))
 }
+zle -N zsh-system-clipboard-put-before
 
 # Cut selection.
-function zsh-system-clipboard-key-x() {
+function zsh-system-clipboard-cut() {
 	zle vi-delete
-	_zsh_system_clipboard_set "$CUTBUFFER"
+	_zsh_system_clipboard set "$CUTBUFFER"
 }
-
-# Cut selection.
-function zsh-system-clipboard-key-d() {
-	zsh-system-clipboard-key-x
-}
+zle -N zsh-system-clipboard-cut
 
 # Bind keys to widgets.
 function () {
-	local key
-
-	# Load functions as widgets
-	foreach key (y yy Y p P x d) {
-		zle -N zsh-system-clipboard-key-$key
-	}
-
-	# Normal mode bindings
-	foreach key (yy Y p P d) {
-		bindkey -M vicmd $key zsh-system-clipboard-key-$key
-	}
-
-	# Visual mode bindings
-	foreach key (y x d) {
-		bindkey -M visual $key zsh-system-clipboard-key-$key
-	}
+	local binded_keys i parts key cmd
+	#
+	binded_keys=(${(f)"$(bindkey -M vicmd)"})
+	for (( i = 1; i < ${#binded_keys[@]}; ++i )); do
+		parts=("${(z)binded_keys[$i]}")
+		key="${parts[1]}"
+		cmd="${parts[2]}"
+		case $cmd in
+			"vi-yank")
+				eval bindkey -M vicmd $key zsh-system-clipboard-yank
+				;;
+			"vi-yank-whole-line")
+				eval bindkey -M vicmd $key zsh-system-clipboard-yank-whole-line
+				;;
+			"vi-put-before")
+				eval bindkey -M vicmd $key zsh-system-clipboard-put-before
+				;;
+			"vi-put-after")
+				eval bindkey -M vicmd $key zsh-system-clipboard-put-after
+				;;
+			"vi-change-eol"|"vi-kill-eol"|"vi-change-whole-line"|"vi-change"|"vi-substitue"|"vi-delete"|"vi-delete-char"|"vi-backward-delete-char")
+				eval bindkey -M vicmd $key zsh-system-clipboard-cut
+				;;
+		esac
+	done
+	binded_keys=(${(f)"$(bindkey -M visual)"})
+	for (( i = 1; i < ${#binded_keys[@]}; ++i )); do
+		parts=("${(z)binded_keys[$i]}")
+		key="${parts[1]}"
+		cmd="${parts[2]}"
+		case $cmd in
+			"put-replace-selection")
+				eval bindkey -M visual $key zsh-system-clipboard-yank
+				;;
+			"vi-delete")
+				eval bindkey -M visual $key zsh-system-clipboard-cut
+				;;
+		esac
+	done
+	# TODO: Run the same kind of commands for `bindkey -M emacs`
 }

--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -11,120 +11,88 @@
 # Enable vi emulation mode explicitly.
 setopt VI
 
-function _zsh_system_clipboard() {
-	function error() {
-		echo -e "\n\n  \033[41;37m ERROR \033[0m \033[01mzsh-system-clipboard:\033[0m $@\n" >&2
-	}
+function error() {
+	echo -e "\n\n  \033[41;37m ERROR \033[0m \033[01mzsh-system-clipboard:\033[0m $@\n" >&2
+}
 
-	function suggest_to_install() {
-		error "Could not find any available clipboard manager. Make sure you have \033[01m${@}\033[0m installed."
-	}
+function suggest_to_install() {
+	error "Could not find any available clipboard manager. Make sure you have \033[01m${@}\033[0m installed."
+}
 
-	local -A CLIPBOARD
-
-	function () {
-		case "$OSTYPE" {
-			darwin*)
-				if ((hash pbcopy && hash pbpaste) 2>/dev/null) {
-					typeset -g CLIPBOARD[set]='pbcopy'
-					typeset -g CLIPBOARD[get]='pbpaste'
-				} else {
-					suggest_to_install 'pbcopy, pbpaste'
-				}
-				;;
-
-			linux-android*)
-				if ((hash termux-clipboard-set && hash termux-clipboard-get) 2>/dev/null) {
-					typeset -g CLIPBOARD[set]='termux-clipboard-set'
-					typeset -g CLIPBOARD[get]='termux-clipboard-get'
-				} else {
-					suggest_to_install 'Termux:API (from Play Store), termux-api (from apt package)'
-				}
-				;;
-
-			linux*|freebsd*)
-				if (hash xclip 2>/dev/null) {
-					local clipboard_selection
-
-					case $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION {
-						PRIMARY)
-							clipboard_selection='PRIMARY'
-							;;
-
-						CLIPBOARD)
-							clipboard_selection='CLIPBOARD'
-							;;
-
-						*)
-							if [[ $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION != '' ]] {
-								error "\033[01m$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION\033[0m is not a valid value for \$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION. Please assign either 'PRIMARY' or 'CLIPBOARD'."
-
-							} else {
-								clipboard_selection='CLIPBOARD'
-							}
-							;;
+declare -A ZSH_SYSTEM_CLIPBOARD
+case "$OSTYPE" {
+	darwin*)
+		if ((hash pbcopy && hash pbpaste) 2>/dev/null) {
+			typeset -g ZSH_SYSTEM_CLIPBOARD[set]='pbcopy'
+			typeset -g ZSH_SYSTEM_CLIPBOARD[get]='pbpaste'
+		} else {
+			suggest_to_install 'pbcopy, pbpaste'
+		}
+		;;
+	linux-android*)
+		if ((hash termux-clipboard-set && hash termux-clipboard-get) 2>/dev/null) {
+			typeset -g ZSH_SYSTEM_CLIPBOARD[set]='termux-clipboard-set'
+			typeset -g ZSH_SYSTEM_CLIPBOARD[get]='termux-clipboard-get'
+		} else {
+			suggest_to_install 'Termux:API (from Play Store), termux-api (from apt package)'
+		}
+		;;
+	linux*|freebsd*)
+		if (hash xclip 2>/dev/null) {
+			local clipboard_selection
+			case $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION {
+				PRIMARY)
+					clipboard_selection='PRIMARY'
+					;;
+				CLIPBOARD)
+					clipboard_selection='CLIPBOARD'
+					;;
+				*)
+					if [[ $ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION != '' ]] {
+						error "\033[01m$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION\033[0m is not a valid value for \$ZSH_SYSTEM_CLIPBOARD_XCLIP_SELECTION. Please assign either 'PRIMARY' or 'CLIPBOARD'."
+					} else {
+						clipboard_selection='CLIPBOARD'
 					}
-
-					typeset -g CLIPBOARD[set]="xclip -sel $clipboard_selection -in"
-					typeset -g CLIPBOARD[get]="xclip -sel $clipboard_selection -out"
-				} else {
-					suggest_to_install 'xclip'
-				}
-				;;
-
-			*)
-				error 'Unsupported system.'
-				;;
-		}
-	}
-
-	function sub_set() {
-		if [[ "$ZSH_SYSTEM_CLIPBOARD_TMUX_SUPPORT" != '' ]] {
-			# Set also tmux clipboard buffer if tmux available.
-			if (hash tmux &>/dev/null && [[ "$TMUX" != '' ]]) {
-				tmux set-buffer -- "$@"
+					;;
 			}
+			typeset -g ZSH_SYSTEM_CLIPBOARD[set]="xclip -sel $clipboard_selection -in"
+			typeset -g ZSH_SYSTEM_CLIPBOARD[get]="xclip -sel $clipboard_selection -out"
+		} else {
+			suggest_to_install 'xclip'
 		}
+		;;
+	*)
+		error 'Unsupported system.'
+		;;
+}
+unfunction error
+unfunction suggest_to_install
 
-		echo -E "$@" | eval "${CLIPBOARD[set]}"
+function _zsh_system_clipboard_set() {
+	if [[ "$ZSH_SYSTEM_CLIPBOARD_TMUX_SUPPORT" != '' ]] {
+		# Set also tmux clipboard buffer if tmux available.
+		if (hash tmux &>/dev/null && [[ "$TMUX" != '' ]]) {
+			tmux set-buffer -- "$*"
+		}
 	}
-
-	function sub_get() {
-		echo -E $(eval ${CLIPBOARD[get]})
-	}
-
-	local subcommand=${1:-''}
-
-	case "$subcommand" {
-		set)
-			shift
-			sub_${subcommand} "$*"
-
-			return true
-			;;
-
-		get)
-			shift
-			sub_${subcommand}
-
-			return true
-			;;
-
-		*)
-			return false
-	}
+	echo -E "$*" | eval "${ZSH_SYSTEM_CLIPBOARD[set]}"
+	return true
+}
+function _zsh_system_clipboard_get() {
+	eval "${ZSH_SYSTEM_CLIPBOARD[get]}"
+	return true
 }
 
 # Copy selection.
 function zsh-system-clipboard-key-y() {
 	zle vi-yank
-	_zsh_system_clipboard set "$CUTBUFFER"
+	_zsh_system_clipboard_set "$CUTBUFFER"
 }
 
 # Copy whole line.
 function zsh-system-clipboard-key-Y() {
 	zle vi-yank-whole-line
-	_zsh_system_clipboard set "$CUTBUFFER"
+	_zsh_system_clipboard_set "$CUTBUFFER"
 }
 
 # Copy whole line.
@@ -134,7 +102,7 @@ function zsh-system-clipboard-key-yy() {
 
 # Paster after cursor.
 function zsh-system-clipboard-key-p() {
-	local CLIPBOARD=$(_zsh_system_clipboard get)
+	local CLIPBOARD=$(_zsh_system_clipboard_get)
 
 	BUFFER="${BUFFER:0:$(( ${CURSOR} + 1 ))}${CLIPBOARD}${BUFFER:$(( ${CURSOR} + 1 ))}"
 	CURSOR=$(( $#LBUFFER + $#CLIPBOARD ))
@@ -142,7 +110,7 @@ function zsh-system-clipboard-key-p() {
 
 # Paste before cursor.
 function zsh-system-clipboard-key-P() {
-	local CLIPBOARD=$(_zsh_system_clipboard get)
+	local CLIPBOARD=$(_zsh_system_clipboard_get)
 
 	BUFFER="${BUFFER:0:$(( ${CURSOR} ))}${CLIPBOARD}${BUFFER:$(( ${CURSOR} ))}"
 	CURSOR=$(( $#LBUFFER + $#CLIPBOARD - 1 ))
@@ -151,7 +119,7 @@ function zsh-system-clipboard-key-P() {
 # Cut selection.
 function zsh-system-clipboard-key-x() {
 	zle vi-delete
-	_zsh_system_clipboard set "$CUTBUFFER"
+	_zsh_system_clipboard_set "$CUTBUFFER"
 }
 
 # Cut selection.

--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -112,85 +112,100 @@ function _zsh_system_clipboard() {
 	}
 }
 
-# Copy selection.
-function zsh-system-clipboard-yank() {
+function zsh-system-clipboard-vicmd-vi-yank() {
 	zle vi-yank
 	_zsh_system_clipboard set "$CUTBUFFER"
 }
-zle -N zsh-system-clipboard-yank
+zle -N zsh-system-clipboard-vicmd-vi-yank
 
-# Copy whole line.
-function zsh-system-clipboard-yank-whole-line() {
+function zsh-system-clipboard-vicmd-vi-yank-whole-line() {
 	zle vi-yank-whole-line
 	_zsh_system_clipboard set "$CUTBUFFER"
 }
-zle -N zsh-system-clipboard-yank-whole-line
+zle -N zsh-system-clipboard-vicmd-vi-yank-whole-line
 
-# Paste after cursor.
-function zsh-system-clipboard-put-after() {
+function zsh-system-clipboard-vicmd-vi-put-after() {
 	local CLIPBOARD=$(_zsh_system_clipboard get)
 
 	BUFFER="${BUFFER:0:$(( ${CURSOR} + 1 ))}${CLIPBOARD}${BUFFER:$(( ${CURSOR} + 1 ))}"
 	CURSOR=$(( $#LBUFFER + $#CLIPBOARD ))
 }
-zle -N zsh-system-clipboard-put-after
+zle -N zsh-system-clipboard-vicmd-vi-put-after
 
-# Paste before cursor.
-function zsh-system-clipboard-put-before() {
+function zsh-system-clipboard-vicmd-vi-put-before() {
 	local CLIPBOARD=$(_zsh_system_clipboard get)
 
 	BUFFER="${BUFFER:0:$(( ${CURSOR} ))}${CLIPBOARD}${BUFFER:$(( ${CURSOR} ))}"
 	CURSOR=$(( $#LBUFFER + $#CLIPBOARD - 1 ))
 }
-zle -N zsh-system-clipboard-put-before
+zle -N zsh-system-clipboard-vicmd-vi-put-before
 
-# Cut selection.
-function zsh-system-clipboard-cut() {
+function zsh-system-clipboard-vicmd-vi-delete() {
 	zle vi-delete
 	_zsh_system_clipboard set "$CUTBUFFER"
 }
-zle -N zsh-system-clipboard-cut
+zle -N zsh-system-clipboard-vicmd-vi-delete
+
+function zsh-system-clipboard-vicmd-vi-delete-char() {
+	zle vi-delete-char
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-delete-char
+
+function zsh-system-clipboard-vicmd-vi-change-eol() {
+	zle vi-change-eol
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-change-eol
+
+function zsh-system-clipboard-vicmd-vi-kill-eol() {
+	zle vi-kill-eol
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-kill-eol
+
+function zsh-system-clipboard-vicmd-vi-change-whole-line() {
+	zle vi-change-whole-line
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-change-whole-line
+
+function zsh-system-clipboard-vicmd-vi-change() {
+	zle vi-change
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-change
+
+function zsh-system-clipboard-vicmd-vi-substitue() {
+	zle vi-substitue
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-substitue
+
+function zsh-system-clipboard-vicmd-vi-delete-char() {
+	zle vi-delete-char
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-delete-char
+
+function zsh-system-clipboard-vicmd-vi-backward-delete-char() {
+	zle vi-backward-delete-char
+	_zsh_system_clipboard set "$CUTBUFFER"
+}
+zle -N zsh-system-clipboard-vicmd-vi-backward-delete-char
 
 # Bind keys to widgets.
 function () {
-	local binded_keys i parts key cmd
-	#
-	binded_keys=(${(f)"$(bindkey -M vicmd)"})
-	for (( i = 1; i < ${#binded_keys[@]}; ++i )); do
-		parts=("${(z)binded_keys[$i]}")
-		key="${parts[1]}"
-		cmd="${parts[2]}"
-		case $cmd in
-			"vi-yank")
-				eval bindkey -M vicmd $key zsh-system-clipboard-yank
-				;;
-			"vi-yank-whole-line")
-				eval bindkey -M vicmd $key zsh-system-clipboard-yank-whole-line
-				;;
-			"vi-put-before")
-				eval bindkey -M vicmd $key zsh-system-clipboard-put-before
-				;;
-			"vi-put-after")
-				eval bindkey -M vicmd $key zsh-system-clipboard-put-after
-				;;
-			"vi-change-eol"|"vi-kill-eol"|"vi-change-whole-line"|"vi-change"|"vi-substitue"|"vi-delete"|"vi-delete-char"|"vi-backward-delete-char")
-				eval bindkey -M vicmd $key zsh-system-clipboard-cut
-				;;
-		esac
+	local binded_keys i parts key cmd keymap
+	for keymap in vicmd visual emacs; do
+		binded_keys=(${(f)"$(bindkey -M $keymap)"})
+		for (( i = 1; i < ${#binded_keys[@]}; ++i )); do
+			parts=("${(z)binded_keys[$i]}")
+			key="${parts[1]}"
+			cmd="${parts[2]}"
+			if (( $+functions[zsh-system-clipboard-$keymap-$cmd] )); then
+				eval bindkey -M $keymap $key zsh-system-clipboard-$keymap-$cmd
+			fi
+		done
 	done
-	binded_keys=(${(f)"$(bindkey -M visual)"})
-	for (( i = 1; i < ${#binded_keys[@]}; ++i )); do
-		parts=("${(z)binded_keys[$i]}")
-		key="${parts[1]}"
-		cmd="${parts[2]}"
-		case $cmd in
-			"put-replace-selection")
-				eval bindkey -M visual $key zsh-system-clipboard-yank
-				;;
-			"vi-delete")
-				eval bindkey -M visual $key zsh-system-clipboard-cut
-				;;
-		esac
-	done
-	# TODO: Run the same kind of commands for `bindkey -M emacs`
 }


### PR DESCRIPTION
Parse the output of `bindkey -M vicmd` and `bindkey -M visual` in order to
rebind the current already set keys to their new functionality. No need to
explicitly `setopt vi` since we assume it is set by most users.
Documentation should be added in order to indicate that currently the emacs
keymap isn't supported. Plus, to quote zsh's documentation on `setopt vi`:

> VI
>     If ZLE is loaded, turning on this option has the equivalent effect
>     of 'bindkey -v'.  In addition, the EMACS option is unset.  Turning
>     it off has no effect.  The option setting is not guaranteed to
>     reflect the current keymap.  This option is provided for
>     compatibility; bindkey is the recommended interface.

Renaming the functions seems reasonable since we don't bind keys according
to their name but according to their already binded functions.