### PR TITLE
Set localoptions to make sure aliases being expanded

### DIFF
--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -10,6 +10,9 @@
 # @version v0.7.0
 ##
 
+# Make sure the aliases being expanded
+setopt localoptions ALIASES
+
 function _zsh_system_clipboard_command_exists() {
 	type "$1" &> /dev/null;
 }


### PR DESCRIPTION
Avoid the problem that aliases are not expanded when the plugin
is loaded by zplugin, which should fix the issue #25.

This seems to be a more simple solution compared with GH-26. 
Just choose whichever you like.