### PR TITLE
Add vi-yank-eol

### DIFF
--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -170,6 +170,12 @@ function zsh-system-clipboard-vicmd-vi-yank() {
 }
 zle -N zsh-system-clipboard-vicmd-vi-yank
 
+function zsh-system-clipboard-vicmd-vi-yank-eol() {
+	zle vi-yank-eol
+	printf '%s' "$CUTBUFFER" | zsh-system-clipboard-set
+}
+zle -N zsh-system-clipboard-vicmd-vi-yank-eol
+
 function zsh-system-clipboard-vicmd-vi-yank-whole-line() {
 	zle vi-yank-whole-line
 	printf '%s\n' "$CUTBUFFER" | zsh-system-clipboard-set


### PR DESCRIPTION
It's common to remap `Y` to yank until end of line so that it works more like `C` and `D`. This adds support for that.