### PR TITLE
fix: non tmux wl-clipboard mode

### DIFF
--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -128,16 +128,12 @@ case "$OSTYPE" {
 				}
 			fi
 		else
-			if [[ ! -z "$DISPLAY" ]]; then
-				zsh-system-clipboard-set(){
-					"${_zsh_system_clipboard_set[@]}"
-				}
-				zsh-system-clipboard-get(){
-					"${_zsh_system_clipboard_get[@]}"
-				}
-			else
-				return 1
-			fi
+			zsh-system-clipboard-set(){
+				"${_zsh_system_clipboard_set[@]}"
+			}
+			zsh-system-clipboard-get(){
+				"${_zsh_system_clipboard_get[@]}"
+			}
 		fi
 		;;
 	*)


### PR DESCRIPTION
This pull request resolves an issue where `zsh-system-clipboard` did not properly set up when using no tmux on a wayland only system. Was this `return 1` intended?