### PR TITLE
Better clipboard tool autodetection for linux/freebsd

### DIFF
--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -40,15 +40,12 @@ if [[ "$ZSH_SYSTEM_CLIPBOARD_METHOD" == "" ]]; then
 			fi
 			;;
 		linux*|freebsd*)
-			if _zsh_system_clipboard_command_exists wl-copy && ( [[ "$WAYLAND_DISPLAY" != "" ]] || [[ "$XDG_SESSION_TYPE" == wayland ]] ); then
+			if _zsh_system_clipboard_command_exists wl-copy && [[ "$WAYLAND_DISPLAY" != "" ]]; then
 				ZSH_SYSTEM_CLIPBOARD_METHOD="wlc"
 			elif _zsh_system_clipboard_command_exists xclip && [[ "$DISPLAY" != "" ]]; then
 				ZSH_SYSTEM_CLIPBOARD_METHOD="xcc"
 			elif _zsh_system_clipboard_command_exists xsel && [[ "$DISPLAY" != "" ]]; then
 				ZSH_SYSTEM_CLIPBOARD_METHOD="xsc"
-			elif [[ "$SSH_TTY" != "" ]] || [[ "$XDG_SESSION_TYPE" == tty ]]; then
-				# Stay silent when there is no GUI running
-				return 0
 			else
 				_zsh_system_clipboard_suggest_to_install 'wl-clipboard / xclip / xsel'
 			fi

--- a/zsh-system-clipboard.zsh
+++ b/zsh-system-clipboard.zsh
@@ -40,12 +40,15 @@ if [[ "$ZSH_SYSTEM_CLIPBOARD_METHOD" == "" ]]; then
 			fi
 			;;
 		linux*|freebsd*)
-			if [[ "$DISPLAY" == "" ]]; then
+			if _zsh_system_clipboard_command_exists wl-copy && ( [[ "$WAYLAND_DISPLAY" != "" ]] || [[ "$XDG_SESSION_TYPE" == wayland ]] ); then
 				ZSH_SYSTEM_CLIPBOARD_METHOD="wlc"
-			elif _zsh_system_clipboard_command_exists xclip; then
+			elif _zsh_system_clipboard_command_exists xclip && [[ "$DISPLAY" != "" ]]; then
 				ZSH_SYSTEM_CLIPBOARD_METHOD="xcc"
-			elif _zsh_system_clipboard_command_exists xsel; then
+			elif _zsh_system_clipboard_command_exists xsel && [[ "$DISPLAY" != "" ]]; then
 				ZSH_SYSTEM_CLIPBOARD_METHOD="xsc"
+			elif [[ "$SSH_TTY" != "" ]] || [[ "$XDG_SESSION_TYPE" == tty ]]; then
+				# Stay silent when there is no GUI running
+				return 0
 			else
 				_zsh_system_clipboard_suggest_to_install 'wl-clipboard / xclip / xsel'
 			fi


### PR DESCRIPTION
Old implementation relied on absence of `$DISPLAY` to detect Wayland. But `$DISPLAY` can be set even in Wayland session. I don't fully know why, I suspect it is because of XWayland.

So it won't pick correct tool.

This implementation relies on `$WAYLAND_DISPLAY`, which won't be set in Xorg session, and `$XDG_SESSION_TYPE` to detect wayland. It also checks if wl-clipboard is installed for consistency.

Additionally, it handles cases when there is no GUI running (SSH session, or TTY).